### PR TITLE
Feature/read table

### DIFF
--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/AdminBoardAutoConfiguration.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/AdminBoardAutoConfiguration.java
@@ -1,5 +1,6 @@
 package com.github.twentiethcenturygangsta.adminboard;
 
+import com.github.twentiethcenturygangsta.adminboard.client.AdminBoardClient;
 import com.github.twentiethcenturygangsta.adminboard.client.EntityClient;
 import com.github.twentiethcenturygangsta.adminboard.repository.RepositoryClient;
 import com.github.twentiethcenturygangsta.adminboard.view.AdminBoardViewController;
@@ -31,8 +32,8 @@ public class AdminBoardAutoConfiguration {
     }
 
     @Bean
-    public AdminBoardFactory adminBoardFactory(RepositoryClient repositoryClient, EntityClient entityClient) {
-        return new AdminBoardFactory(repositoryClient, entityClient);
+    public AdminBoardFactory adminBoardFactory(RepositoryClient repositoryClient,  AdminBoardClient adminBoardClient, EntityClient entityClient) {
+        return new AdminBoardFactory(repositoryClient, adminBoardClient, entityClient);
     }
 
     @Bean

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/AdminBoardFactory.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/AdminBoardFactory.java
@@ -11,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.ListPagingAndSortingRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Service;
@@ -67,17 +69,52 @@ public class AdminBoardFactory {
     }
 
     public Page<?> getObjects(String entityName, Pageable pageable) {
+        Long id = 1L;
         RepositoryInfo repositoryInfo = repositoryClient.getRepository(entityName);
         if(repositoryInfo.getRepositoryType() == JpaRepository.class) {
-            JpaRepository<?, ?> repository = RepositoryBuilder.getJpaRepositoryInstance(repositoryInfo.getRepositoryObject());
+            JpaRepository<?, ?> repository = RepositoryBuilder.getJpaRepositoryInstance(
+                    repositoryInfo.getRepositoryObject(),
+                    repositoryInfo.getDomain(),
+                    repositoryInfo.getIdType()
+            );
             return repository.findAll(pageable);
         }
         if(repositoryInfo.getRepositoryType() == PagingAndSortingRepository.class) {
-            PagingAndSortingRepository<?, ?> repository = RepositoryBuilder.getPagingAndSortingRepositoryInstance(repositoryInfo.getRepositoryObject());
+            PagingAndSortingRepository<?, ?> repository = RepositoryBuilder.getPagingAndSortingRepositoryInstance(
+                    repositoryInfo.getRepositoryObject(),
+                    repositoryInfo.getDomain(),
+                    repositoryInfo.getIdType()
+            );
             return repository.findAll(pageable);
         }
-        ListPagingAndSortingRepository<?, ?> repository = RepositoryBuilder.getListPagingAndSortingRepositoryInstance(repositoryInfo.getRepositoryObject());
+        ListPagingAndSortingRepository<?, ?> repository = RepositoryBuilder.getListPagingAndSortingRepositoryInstance(
+                repositoryInfo.getRepositoryObject(),
+                repositoryInfo.getDomain(),
+                repositoryInfo.getIdType()
+        );
         return repository.findAll(pageable);
+    }
+
+    public Optional<Object> getObject(String entityName, Long entityObjectId) {
+        RepositoryInfo repositoryInfo = repositoryClient.getRepository(entityName);
+        if(repositoryInfo.getRepositoryType() == JpaRepository.class) {
+            JpaRepository<Object, Object> repository = RepositoryBuilder.getJpaRepositoryInstance(repositoryInfo.getRepositoryObject(), repositoryInfo.getDomain(), repositoryInfo.getIdType());
+            return repository.findById(entityObjectId);
+        }
+        if(repositoryInfo.getRepositoryType() == CrudRepository.class) {
+            CrudRepository<Object, Object> repository = RepositoryBuilder.getCrudRepositoryInstance(
+                    repositoryInfo.getRepositoryObject(),
+                    repositoryInfo.getDomain(),
+                    repositoryInfo.getIdType()
+            );
+            return repository.findById(entityObjectId);
+        }
+        ListCrudRepository<Object, Object> repository = RepositoryBuilder.getListCrudRepositoryInstance(
+                repositoryInfo.getRepositoryObject(),
+                repositoryInfo.getDomain(),
+                repositoryInfo.getIdType()
+        );
+        return repository.findById(entityObjectId);
     }
 
     public Object getFieldMappingValue(Object root, String fieldName ) {

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/AdminBoardFactory.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/AdminBoardFactory.java
@@ -69,7 +69,6 @@ public class AdminBoardFactory {
     }
 
     public Page<?> getObjects(String entityName, Pageable pageable) {
-        Long id = 1L;
         RepositoryInfo repositoryInfo = repositoryClient.getRepository(entityName);
         if(repositoryInfo.getRepositoryType() == JpaRepository.class) {
             JpaRepository<?, ?> repository = RepositoryBuilder.getJpaRepositoryInstance(
@@ -127,31 +126,6 @@ public class AdminBoardFactory {
             );
 
             return getter.invoke(root);
-        } catch (Exception e) {
-            // log exception
-        }
-        return null;
-    }
-    public Object getFieldMappingValueDepth(Object root, String fieldName) {
-        try {
-            Field field = root.getClass().getDeclaredField( fieldName );
-            Method getter = root.getClass().getDeclaredMethod(
-                    (field.getType().equals( boolean.class ) ? "is" : "get")
-                            + field.getName().substring(0, 1).toUpperCase( Locale.ROOT)
-                            + field.getName().substring(1)
-            );
-
-            Field field1 = root.getClass().getDeclaredField("id");
-            Method getter1 = root.getClass().getDeclaredMethod(
-                    (field1.getType().equals( boolean.class ) ? "is" : "get")
-                            + field1.getName().substring(0, 1).toUpperCase( Locale.ROOT)
-                            + field1.getName().substring(1)
-            );
-
-
-            Object object = getter.invoke(root);
-
-            return getter1.invoke(object);
         } catch (Exception e) {
             // log exception
         }

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/AdminBoardFactory.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/AdminBoardFactory.java
@@ -4,10 +4,19 @@ import com.github.twentiethcenturygangsta.adminboard.client.AdminBoardClient;
 import com.github.twentiethcenturygangsta.adminboard.client.AdminBoardInfo;
 import com.github.twentiethcenturygangsta.adminboard.client.EntityClient;
 import com.github.twentiethcenturygangsta.adminboard.entity.EntityInfo;
+import com.github.twentiethcenturygangsta.adminboard.repository.RepositoryBuilder;
 import com.github.twentiethcenturygangsta.adminboard.repository.RepositoryClient;
+import com.github.twentiethcenturygangsta.adminboard.repository.RepositoryInfo;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.ListPagingAndSortingRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Service;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.*;
 
 @Slf4j
@@ -42,6 +51,9 @@ public class AdminBoardFactory {
     public List<EntityInfo> getEntities() {
         return entityClient.getEntities();
     }
+    public EntityInfo getEntity(String entityName){
+        return entityClient.getEntity(entityName);
+    }
 
     public HashMap<String, String> getAdminBoardInfo() {
         HashMap<String, String> adminBoardInfoTable = new HashMap<>();
@@ -52,5 +64,60 @@ public class AdminBoardFactory {
         adminBoardInfoTable.put("licenseUrl", adminBoardInfo.getLicenseUrl());
         adminBoardInfoTable.put("version", adminBoardInfo.getVersion());
         return adminBoardInfoTable;
+    }
+
+    public Page<?> getObjects(String entityName, Pageable pageable) {
+        RepositoryInfo repositoryInfo = repositoryClient.getRepository(entityName);
+        if(repositoryInfo.getRepositoryType() == JpaRepository.class) {
+            JpaRepository<?, ?> repository = RepositoryBuilder.getJpaRepositoryInstance(repositoryInfo.getRepositoryObject());
+            return repository.findAll(pageable);
+        }
+        if(repositoryInfo.getRepositoryType() == PagingAndSortingRepository.class) {
+            PagingAndSortingRepository<?, ?> repository = RepositoryBuilder.getPagingAndSortingRepositoryInstance(repositoryInfo.getRepositoryObject());
+            return repository.findAll(pageable);
+        }
+        ListPagingAndSortingRepository<?, ?> repository = RepositoryBuilder.getListPagingAndSortingRepositoryInstance(repositoryInfo.getRepositoryObject());
+        return repository.findAll(pageable);
+    }
+
+    public Object getFieldMappingValue(Object root, String fieldName ) {
+        try {
+            Field field = root.getClass().getDeclaredField( fieldName );
+            Method getter = root.getClass().getDeclaredMethod(
+                    (field.getType().equals( boolean.class ) ? "is" : "get")
+                            + field.getName().substring(0, 1).toUpperCase( Locale.ROOT)
+                            + field.getName().substring(1)
+            );
+
+            return getter.invoke(root);
+        } catch (Exception e) {
+            // log exception
+        }
+        return null;
+    }
+    public Object getFieldMappingValueDepth(Object root, String fieldName) {
+        try {
+            Field field = root.getClass().getDeclaredField( fieldName );
+            Method getter = root.getClass().getDeclaredMethod(
+                    (field.getType().equals( boolean.class ) ? "is" : "get")
+                            + field.getName().substring(0, 1).toUpperCase( Locale.ROOT)
+                            + field.getName().substring(1)
+            );
+
+            Field field1 = root.getClass().getDeclaredField("id");
+            Method getter1 = root.getClass().getDeclaredMethod(
+                    (field1.getType().equals( boolean.class ) ? "is" : "get")
+                            + field1.getName().substring(0, 1).toUpperCase( Locale.ROOT)
+                            + field1.getName().substring(1)
+            );
+
+
+            Object object = getter.invoke(root);
+
+            return getter1.invoke(object);
+        } catch (Exception e) {
+            // log exception
+        }
+        return null;
     }
 }

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/AdminBoardFactory.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/AdminBoardFactory.java
@@ -1,5 +1,7 @@
 package com.github.twentiethcenturygangsta.adminboard;
 
+import com.github.twentiethcenturygangsta.adminboard.client.AdminBoardClient;
+import com.github.twentiethcenturygangsta.adminboard.client.AdminBoardInfo;
 import com.github.twentiethcenturygangsta.adminboard.client.EntityClient;
 import com.github.twentiethcenturygangsta.adminboard.entity.EntityInfo;
 import com.github.twentiethcenturygangsta.adminboard.repository.RepositoryClient;
@@ -13,10 +15,13 @@ import java.util.*;
 public class AdminBoardFactory {
     private final RepositoryClient repositoryClient;
     private final EntityClient entityClient;
+    private final AdminBoardClient adminBoardClient;
 
-    public AdminBoardFactory(final RepositoryClient repositoryClient, final EntityClient entityClient) {
+
+    public AdminBoardFactory(final RepositoryClient repositoryClient, final AdminBoardClient adminBoardClient, final EntityClient entityClient) {
         this.repositoryClient = repositoryClient;
         this.entityClient = entityClient;
+        this.adminBoardClient = adminBoardClient;
     }
 
     public  HashMap<String, ArrayList<EntityInfo>> getEntitiesByGroup() {
@@ -36,5 +41,16 @@ public class AdminBoardFactory {
 
     public List<EntityInfo> getEntities() {
         return entityClient.getEntities();
+    }
+
+    public HashMap<String, String> getAdminBoardInfo() {
+        HashMap<String, String> adminBoardInfoTable = new HashMap<>();
+        AdminBoardInfo adminBoardInfo = adminBoardClient.getAdminBoardInfo();
+        adminBoardInfoTable.put("title", adminBoardInfo.getTitle());
+        adminBoardInfoTable.put("description", adminBoardInfo.getDescription());
+        adminBoardInfoTable.put("license", adminBoardInfo.getLicense());
+        adminBoardInfoTable.put("licenseUrl", adminBoardInfo.getLicenseUrl());
+        adminBoardInfoTable.put("version", adminBoardInfo.getVersion());
+        return adminBoardInfoTable;
     }
 }

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/annotation/registrar/AdminBoardRegistrar.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/annotation/registrar/AdminBoardRegistrar.java
@@ -28,7 +28,7 @@ public class AdminBoardRegistrar implements ImportBeanDefinitionRegistrar {
         if (basePackages.length == 0) {
             packages.add(ClassUtils.getPackageName(importingClassMetadata.getClassName()));
         } else {
-            packages = Arrays.asList(basePackages);
+            packages.addAll(Arrays.asList(basePackages));
         }
         packages.add(ADMIN_BOARD_PACKAGE_NAME);
     }

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/client/AdminBoardClient.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/client/AdminBoardClient.java
@@ -1,7 +1,9 @@
 package com.github.twentiethcenturygangsta.adminboard.client;
 
 import lombok.Builder;
+import org.springframework.stereotype.Component;
 
+@Component
 public class AdminBoardClient {
 
     private final UserCredentials userCredentials;

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/client/AdminBoardInfo.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/client/AdminBoardInfo.java
@@ -3,11 +3,11 @@ package com.github.twentiethcenturygangsta.adminboard.client;
 import lombok.Builder;
 
 public class AdminBoardInfo {
-    private String title;
-    private String description;
-    private String license;
-    private String licenseUrl;
-    private String version;
+    private final String title;
+    private final String description;
+    private final String license;
+    private final String licenseUrl;
+    private final String version;
 
     @Builder
     public AdminBoardInfo(String title, String description, String license, String licenseUrl, String version) {
@@ -17,4 +17,14 @@ public class AdminBoardInfo {
         this.licenseUrl = licenseUrl;
         this.version = version;
     }
+
+    public String getTitle() {
+        return title;
+    }
+    public String getDescription() {
+        return description;
+    }
+    public String getLicense() {return license;}
+    public String getLicenseUrl() {return licenseUrl;}
+    public String getVersion() {return version;}
 }

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/entity/ColumnInfo.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/entity/ColumnInfo.java
@@ -41,6 +41,14 @@ public class ColumnInfo {
         this.isAllowedBlank = field.isAnnotationPresent(NotBlank.class);
     }
 
+    public boolean getIsId() {
+        return isId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
     private String getFieldDisplayName(Field field) {
         return AdminBoardStringConvertUtil.getFormattedColumnName(field.getName());
     }

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/entity/EntityInfo.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/entity/EntityInfo.java
@@ -46,7 +46,7 @@ public class EntityInfo {
     private List<ColumnInfo> getObjectColumns(Class<?> object) {
         List<ColumnInfo> columns = new ArrayList<>();
         for (Field field : object.getDeclaredFields()) {
-            if (isStaticField(field)) {
+            if (!isStaticField(field)) {
                 ColumnInfo column = ColumnInfo.builder().field(field).build();
                 columns.add(column);
             }

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/entity/EntityInfo.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/entity/EntityInfo.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -45,8 +46,10 @@ public class EntityInfo {
     private List<ColumnInfo> getObjectColumns(Class<?> object) {
         List<ColumnInfo> columns = new ArrayList<>();
         for (Field field : object.getDeclaredFields()) {
-            ColumnInfo column = ColumnInfo.builder().field(field).build();
-            columns.add(column);
+            if (isStaticField(field)) {
+                ColumnInfo column = ColumnInfo.builder().field(field).build();
+                columns.add(column);
+            }
         }
         return columns;
     }
@@ -60,5 +63,9 @@ public class EntityInfo {
             return annotationsWithAdminBoardEntity.get(0);
         }
         throw new RuntimeException("Not AdminBoardEntity");
+    }
+
+    private boolean isStaticField(Field field) {
+        return Modifier.isStatic(field.getModifiers());
     }
 }

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/repository/RepositoryBuilder.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/repository/RepositoryBuilder.java
@@ -8,23 +8,23 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 
 public class RepositoryBuilder {
 
-    public static JpaRepository<?, ?> getJpaRepositoryInstance(Object object) {
-        return (JpaRepository<?, ?>) object;
+    public static <T, ID> JpaRepository<T, ID> getJpaRepositoryInstance(Object object, T domain, ID id ) {
+        return (JpaRepository<T, ID>) object;
     }
 
-    public static CrudRepository<?, ?> getCrudRepositoryInstance(Object object) {
-        return (CrudRepository<?, ?>) object;
+    public static <T, ID> CrudRepository<T, ID> getCrudRepositoryInstance(Object object, T domain, ID id) {
+        return (CrudRepository<T, ID>) object;
     }
 
-    public static ListCrudRepository<?, ?> getListCrudRepositoryInstance(Object object) {
-        return (ListCrudRepository<?, ?>) object;
+    public static <T, ID> ListCrudRepository<T, ID> getListCrudRepositoryInstance(Object object, T domain, ID id) {
+        return (ListCrudRepository<T, ID>) object;
     }
 
-    public static ListPagingAndSortingRepository<?, ?> getListPagingAndSortingRepositoryInstance(Object object) {
-        return (ListPagingAndSortingRepository<?, ?>) object;
+    public static <T, ID> ListPagingAndSortingRepository<T, ID> getListPagingAndSortingRepositoryInstance(Object object, T domain, ID id) {
+        return (ListPagingAndSortingRepository<T, ID>) object;
     }
 
-    public static PagingAndSortingRepository<?, ?> getPagingAndSortingRepositoryInstance(Object object) {
-        return (PagingAndSortingRepository<?, ?>) object;
+    public static <T, ID> PagingAndSortingRepository<T, ID> getPagingAndSortingRepositoryInstance(Object object, T domain, ID id) {
+        return (PagingAndSortingRepository<T, ID>) object;
     }
 }

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/repository/RepositoryInfo.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/repository/RepositoryInfo.java
@@ -16,6 +16,7 @@ public class RepositoryInfo {
     private final Object repositoryObject;
     private final Object idType;
     private final String domainName;
+    private final Object domain;
 
     @Builder
     public RepositoryInfo(List<Class<?>> repositoryInterfaces, Object repositoryObject, DefaultRepositoryMetadata metaData) {
@@ -23,6 +24,7 @@ public class RepositoryInfo {
         this.repositoryObject = repositoryObject;
         this.idType = metaData.getIdType();
         this.domainName = getRepositoryDomainName(metaData);
+        this.domain = metaData.getDomainType();
     }
 
     private String getRepositoryDomainName(DefaultRepositoryMetadata metadata) {

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/repository/RepositoryInfo.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/repository/RepositoryInfo.java
@@ -26,7 +26,7 @@ public class RepositoryInfo {
     }
 
     private String getRepositoryDomainName(DefaultRepositoryMetadata metadata) {
-        return AdminBoardStringConvertUtil.getFormattedTableName(metadata.getDomainType().getSimpleName());
+        return metadata.getDomainType().getSimpleName();
     }
 
     private Class<?> getRepositoryType(List<Class<?>> repositoryInterfaces) {

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/view/AdminBoardViewController.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/view/AdminBoardViewController.java
@@ -35,8 +35,16 @@ public class AdminBoardViewController {
         return "user";
     }
 
+    @GetMapping("/admin-user")
+    public String AdminUserView(Model model) {
+        getSideBarModel(model);
+        model.addAttribute("data", adminBoardFactory.getEntities());
+        return "adminUser";
+    }
+
     @GetMapping("/table")
     public String TableView(Model model) {
+        getSideBarModel(model);
         model.addAttribute("data", adminBoardFactory.getEntities());
         return "table";
     }

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/view/AdminBoardViewController.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/view/AdminBoardViewController.java
@@ -19,6 +19,7 @@ public class AdminBoardViewController {
 
     @GetMapping("/home")
     public String HomeView(Model model) {
+        model.addAttribute("adminBoardInformation", adminBoardFactory.getAdminBoardInfo());
         model.addAttribute("data", adminBoardFactory.getEntitiesByGroup());
         model.addAttribute("entities", adminBoardFactory.getEntities());
         log.info("entities = {}", adminBoardFactory.getEntities());

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/view/AdminBoardViewController.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/view/AdminBoardViewController.java
@@ -2,9 +2,12 @@ package com.github.twentiethcenturygangsta.adminboard.view;
 
 import com.github.twentiethcenturygangsta.adminboard.AdminBoardFactory;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Slf4j
@@ -19,9 +22,7 @@ public class AdminBoardViewController {
 
     @GetMapping("/home")
     public String HomeView(Model model) {
-        model.addAttribute("adminBoardInformation", adminBoardFactory.getAdminBoardInfo());
-        model.addAttribute("data", adminBoardFactory.getEntitiesByGroup());
-        model.addAttribute("entities", adminBoardFactory.getEntities());
+
         log.info("entities = {}", adminBoardFactory.getEntities());
         log.info("data = {}", adminBoardFactory.getEntitiesByGroup());
 
@@ -39,7 +40,18 @@ public class AdminBoardViewController {
     public String AdminUserView(Model model) {
         getSideBarModel(model);
         model.addAttribute("data", adminBoardFactory.getEntities());
+        model.addAttribute("entityName", "AdminUser");
         return "adminUser";
+    }
+
+    @GetMapping("/{entityName}")
+    public String EntityView(Model model, @PathVariable("entityName") String entityName, @PageableDefault Pageable pageable) {
+        getSideBarModel(model);
+        model.addAttribute("data", adminBoardFactory.getObjects(entityName, pageable));
+        model.addAttribute("entity", adminBoardFactory.getEntity(entityName));
+        model.addAttribute("entityName", entityName);
+
+        return "entity";
     }
 
     @GetMapping("/table")
@@ -88,10 +100,13 @@ public class AdminBoardViewController {
     @GetMapping("/tasks")
     public String TaskView(Model model) {
         getSideBarModel(model);
+        model.addAttribute("entityName", "tasks");
         return "tasks";
     }
 
     private void getSideBarModel(Model model) {
         model.addAttribute("adminBoardInformation", adminBoardFactory.getAdminBoardInfo());
+        model.addAttribute("entitiesByGroup", adminBoardFactory.getEntitiesByGroup());
+        model.addAttribute("entities", adminBoardFactory.getEntities());
     }
 }

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/view/AdminBoardViewController.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/view/AdminBoardViewController.java
@@ -30,6 +30,7 @@ public class AdminBoardViewController {
 
     @GetMapping("/user")
     public String ProfileView(Model model) {
+        getSideBarModel(model);
         model.addAttribute("data", adminBoardFactory.getEntities());
         return "user";
     }
@@ -74,5 +75,15 @@ public class AdminBoardViewController {
     @GetMapping("/login")
     public String LoginView(Model model) {
         return "login";
+    }
+
+    @GetMapping("/tasks")
+    public String TaskView(Model model) {
+        getSideBarModel(model);
+        return "tasks";
+    }
+
+    private void getSideBarModel(Model model) {
+        model.addAttribute("adminBoardInformation", adminBoardFactory.getAdminBoardInfo());
     }
 }

--- a/src/main/java/com/github/twentiethcenturygangsta/adminboard/view/AdminBoardViewController.java
+++ b/src/main/java/com/github/twentiethcenturygangsta/adminboard/view/AdminBoardViewController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import java.util.Optional;
+
 @Slf4j
 @Controller
 @RequestMapping("/admin-board")
@@ -52,6 +54,25 @@ public class AdminBoardViewController {
         model.addAttribute("entityName", entityName);
 
         return "entity";
+    }
+
+    @GetMapping("/{entityName}/{id}")
+    public String EntityDetailView(
+            Model model,
+            @PathVariable("entityName") String entityName,
+            @PathVariable("id") Long id) {
+        getSideBarModel(model);
+        model.addAttribute("entity", adminBoardFactory.getEntity(entityName));
+        Object returnObject = null;
+        Optional<Object> object = adminBoardFactory.getObject(entityName, id);
+        if (object.isPresent()) {
+            returnObject = object.get();
+        }
+        model.addAttribute("object", returnObject);
+        model.addAttribute("entityName", entityName);
+        model.addAttribute("entities", adminBoardFactory.getEntities());
+
+        return "objectDetail";
     }
 
     @GetMapping("/table")

--- a/src/main/resources/templates/adminUser.html
+++ b/src/main/resources/templates/adminUser.html
@@ -1,0 +1,307 @@
+<!--
+=========================================================
+ Light Bootstrap Dashboard - v2.0.1
+=========================================================
+
+ Product Page: https://www.creative-tim.com/product/light-bootstrap-dashboard
+ Copyright 2019 Creative Tim (https://www.creative-tim.com)
+ Licensed under MIT (https://github.com/creativetimofficial/light-bootstrap-dashboard/blob/master/LICENSE)
+
+ Coded by Creative Tim
+
+=========================================================
+
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.  -->
+<!DOCTYPE html>
+<html lang="en">
+
+<th:block th:replace="~{fragments/header :: AdminHeadFragment}"/>
+
+<body>
+<div class="wrapper">
+    <th:block th:replace="~{fragments/sidebar :: SideBarFragment}"/>
+    <div class="main-panel">
+        <!-- Navbar -->
+        <nav class="navbar navbar-expand-lg " color-on-scroll="500">
+            <div class="container-fluid">
+                <a class="navbar-brand" href="#pablo"> Admin Users</a>
+                <button href="" class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" aria-controls="navigation-index" aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-bar burger-lines"></span>
+                    <span class="navbar-toggler-bar burger-lines"></span>
+                    <span class="navbar-toggler-bar burger-lines"></span>
+                </button>
+                <div class="collapse navbar-collapse justify-content-end" id="navigation">
+                    <ul class="nav navbar-nav mr-auto">
+                        <li class="nav-item">
+                            <a href="#" class="nav-link" data-toggle="dropdown">
+                                <i class="nc-icon nc-palette"></i>
+                                <span class="d-lg-none">Dashboard</span>
+                            </a>
+                        </li>
+                        <li class="dropdown nav-item">
+                            <a href="#" class="dropdown-toggle nav-link" data-toggle="dropdown">
+                                <i class="nc-icon nc-planet"></i>
+                                <span class="notification">5</span>
+                                <span class="d-lg-none">Notification</span>
+                            </a>
+                            <ul class="dropdown-menu">
+                                <a class="dropdown-item" href="#">Notification 1</a>
+                                <a class="dropdown-item" href="#">Notification 2</a>
+                                <a class="dropdown-item" href="#">Notification 3</a>
+                                <a class="dropdown-item" href="#">Notification 4</a>
+                                <a class="dropdown-item" href="#">Another notification</a>
+                            </ul>
+                        </li>
+                        <li class="nav-item">
+                            <a href="#" class="nav-link">
+                                <i class="nc-icon nc-zoom-split"></i>
+                                <span class="d-lg-block">&nbsp;Search</span>
+                            </a>
+                        </li>
+                    </ul>
+                    <ul class="navbar-nav ml-auto">
+                        <li class="nav-item">
+                            <a class="nav-link" href="#pablo">
+                                <span class="no-icon">Account</span>
+                            </a>
+                        </li>
+                        <li class="nav-item dropdown">
+                            <a class="nav-link dropdown-toggle" href="http://example.com" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="no-icon">Dropdown</span>
+                            </a>
+                            <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                                <a class="dropdown-item" href="#">Action</a>
+                                <a class="dropdown-item" href="#">Another action</a>
+                                <a class="dropdown-item" href="#">Something</a>
+                                <a class="dropdown-item" href="#">Something else here</a>
+                                <div class="divider"></div>
+                                <a class="dropdown-item" href="#">Separated link</a>
+                            </div>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="#pablo">
+                                <span class="no-icon">Log out</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+        <!-- End Navbar -->
+        <div class="content">
+            <div class="container-fluid">
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="card strpied-tabled-with-hover">
+                            <div class="card-header ">
+                                <h4 class="card-title">Admin User Table</h4>
+                                <p class="card-category">AdminBoard를 이용할 수 있는 Admin 계정 데이터 테이블입니다.</p>
+                            </div>
+                            <div class="card-body table-full-width table-responsive">
+                                <table class="table table-hover table-striped">
+                                    <thead>
+                                    <th>ID</th>
+                                    <th>Name</th>
+                                    <th>Salary</th>
+                                    <th>Country</th>
+                                    <th>City</th>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td>1</td>
+                                        <td>Dakota Rice</td>
+                                        <td>$36,738</td>
+                                        <td>Niger</td>
+                                        <td>Oud-Turnhout</td>
+                                    </tr>
+                                    <tr>
+                                        <td>2</td>
+                                        <td>Minerva Hooper</td>
+                                        <td>$23,789</td>
+                                        <td>Curaçao</td>
+                                        <td>Sinaai-Waas</td>
+                                    </tr>
+                                    <tr>
+                                        <td>3</td>
+                                        <td>Sage Rodriguez</td>
+                                        <td>$56,142</td>
+                                        <td>Netherlands</td>
+                                        <td>Baileux</td>
+                                    </tr>
+                                    <tr>
+                                        <td>4</td>
+                                        <td>Philip Chaney</td>
+                                        <td>$38,735</td>
+                                        <td>Korea, South</td>
+                                        <td>Overland Park</td>
+                                    </tr>
+                                    <tr>
+                                        <td>5</td>
+                                        <td>Doris Greene</td>
+                                        <td>$63,542</td>
+                                        <td>Malawi</td>
+                                        <td>Feldkirchen in Kärnten</td>
+                                    </tr>
+                                    <tr>
+                                        <td>6</td>
+                                        <td>Mason Porter</td>
+                                        <td>$78,615</td>
+                                        <td>Chile</td>
+                                        <td>Gloucester</td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <nav aria-label="Page navigation example">
+                                <ul class="pagination justify-content-center">
+                                    <li class="page-item disabled">
+                                        <a class="page-link">Previous</a>
+                                    </li>
+                                    <li class="page-item"><a class="page-link" href="#">1</a></li>
+                                    <li class="page-item"><a class="page-link" href="#">2</a></li>
+                                    <li class="page-item"><a class="page-link" href="#">3</a></li>
+                                    <li class="page-item">
+                                        <a class="page-link" href="#">Next</a>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <footer class="footer">
+            <div class="container-fluid">
+                <nav>
+                    <ul class="footer-menu">
+                        <li>
+                            <a href="#">
+                                Home
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#">
+                                Company
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#">
+                                Portfolio
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#">
+                                Blog
+                            </a>
+                        </li>
+                    </ul>
+                    <p class="copyright text-center">
+                        ©
+                        <script>
+                            document.write(new Date().getFullYear())
+                        </script>
+                        <a href="http://www.creative-tim.com">Creative Tim</a>, made with love for a better web
+                    </p>
+                </nav>
+            </div>
+        </footer>
+    </div>
+</div>
+<!--   -->
+<!-- <div class="fixed-plugin">
+<div class="dropdown show-dropdown">
+    <a href="#" data-toggle="dropdown">
+        <i class="fa fa-cog fa-2x"> </i>
+    </a>
+
+    <ul class="dropdown-menu">
+        <li class="header-title"> Sidebar Style</li>
+        <li class="adjustments-line">
+            <a href="javascript:void(0)" class="switch-trigger">
+                <p>Background Image</p>
+                <label class="switch">
+                    <input type="checkbox" data-toggle="switch" checked="" data-on-color="primary" data-off-color="primary"><span class="toggle"></span>
+                </label>
+                <div class="clearfix"></div>
+            </a>
+        </li>
+        <li class="adjustments-line">
+            <a href="javascript:void(0)" class="switch-trigger background-color">
+                <p>Filters</p>
+                <div class="pull-right">
+                    <span class="badge filter badge-black" data-color="black"></span>
+                    <span class="badge filter badge-azure" data-color="azure"></span>
+                    <span class="badge filter badge-green" data-color="green"></span>
+                    <span class="badge filter badge-orange" data-color="orange"></span>
+                    <span class="badge filter badge-red" data-color="red"></span>
+                    <span class="badge filter badge-purple active" data-color="purple"></span>
+                </div>
+                <div class="clearfix"></div>
+            </a>
+        </li>
+        <li class="header-title">Sidebar Images</li>
+
+        <li class="active">
+            <a class="img-holder switch-trigger" href="javascript:void(0)">
+                <img src="../assets/img/sidebar-1.jpg" alt="" />
+            </a>
+        </li>
+        <li>
+            <a class="img-holder switch-trigger" href="javascript:void(0)">
+                <img src="../assets/img/sidebar-3.jpg" alt="" />
+            </a>
+        </li>
+        <li>
+            <a class="img-holder switch-trigger" href="javascript:void(0)">
+                <img src="..//assets/img/sidebar-4.jpg" alt="" />
+            </a>
+        </li>
+        <li>
+            <a class="img-holder switch-trigger" href="javascript:void(0)">
+                <img src="../assets/img/sidebar-5.jpg" alt="" />
+            </a>
+        </li>
+
+        <li class="button-container">
+            <div class="">
+                <a href="http://www.creative-tim.com/product/light-bootstrap-dashboard" target="_blank" class="btn btn-info btn-block btn-fill">Download, it's free!</a>
+            </div>
+        </li>
+
+        <li class="header-title pro-title text-center">Want more components?</li>
+
+        <li class="button-container">
+            <div class="">
+                <a href="http://www.creative-tim.com/product/light-bootstrap-dashboard-pro" target="_blank" class="btn btn-warning btn-block btn-fill">Get The PRO Version!</a>
+            </div>
+        </li>
+
+        <li class="header-title" id="sharrreTitle">Thank you for sharing!</li>
+
+        <li class="button-container">
+            <button id="twitter" class="btn btn-social btn-outline btn-twitter btn-round sharrre"><i class="fa fa-twitter"></i> · 256</button>
+            <button id="facebook" class="btn btn-social btn-outline btn-facebook btn-round sharrre"><i class="fa fa-facebook-square"></i> · 426</button>
+        </li>
+    </ul>
+</div>
+</div>
+-->
+</body>
+<!--   Core JS Files   -->
+<script src="/adminboard-resources/assets/js/core/jquery.3.2.1.min.js" type="text/javascript"></script>
+<script src="/adminboard-resources/assets/js/core/popper.min.js" type="text/javascript"></script>
+<script src="/adminboard-resources/assets/js/core/bootstrap.min.js" type="text/javascript"></script>
+<!--  Plugin for Switches, full documentation here: http://www.jque.re/plugins/version3/bootstrap.switch/ -->
+<script src="/adminboard-resources/assets/js/plugins/bootstrap-switch.js"></script>
+<!--  Google Maps Plugin    -->
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=YOUR_KEY_HERE"></script>
+<!--  Chartist Plugin  -->
+<script src="/adminboard-resources/assets/js/plugins/chartist.min.js"></script>
+<!--  Notifications Plugin    -->
+<script src="/adminboard-resources/assets/js/plugins/bootstrap-notify.js"></script>
+<!-- Control Center for Light Bootstrap Dashboard: scripts for the example pages etc -->
+<script src="/adminboard-resources/assets/js/light-bootstrap-dashboard.js?v=2.0.0 " type="text/javascript"></script>
+<!-- Light Bootstrap Dashboard DEMO methods, don't include it in your project! -->
+<script src="/adminboard-resources/assets/js/demo.js"></script>
+
+</html>

--- a/src/main/resources/templates/entity.html
+++ b/src/main/resources/templates/entity.html
@@ -24,7 +24,7 @@
         <!-- Navbar -->
         <nav class="navbar navbar-expand-lg " color-on-scroll="500">
             <div class="container-fluid">
-                <a class="navbar-brand" href="#pablo"> Admin Users</a>
+                <a class="navbar-brand" href="#pablo" th:text="${groupName}"></a>
                 <button href="" class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" aria-controls="navigation-index" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-bar burger-lines"></span>
                     <span class="navbar-toggler-bar burger-lines"></span>
@@ -94,61 +94,88 @@
                     <div class="col-md-12">
                         <div class="card strpied-tabled-with-hover">
                             <div class="card-header ">
-                                <h4 class="card-title">Admin User Table</h4>
-                                <p class="card-category">AdminBoard를 이용할 수 있는 Admin 계정 데이터 테이블입니다.</p>
+                                <h4 class="card-title"><span th:text="${entityName}"></span> Table </h4>
+                                <p class="card-category"><span th:text="${entity.getDescription()}"></span></p>
                             </div>
                             <div class="card-body table-full-width table-responsive">
                                 <table class="table table-hover table-striped">
                                     <thead>
-                                    <th>ID</th>
-                                    <th>Name</th>
-                                    <th>Salary</th>
-                                    <th>Country</th>
-                                    <th>City</th>
+                                    <th:block th:each="field, i : ${entity.getColumns()}">
+                                        <th:block th:if="${i.count le 6}">
+                                            <th>
+                                                <span th:text="${field.getName()}"></span>
+                                            </th>
+                                        </th:block>
+<!--                                    <th>ID</th>-->
+<!--                                    <th>Name</th>-->
+<!--                                    <th>Salary</th>-->
+<!--                                    <th>Country</th>-->
+<!--                                    <th>City</th>-->
+                                    </th:block>
                                     </thead>
                                     <tbody>
-                                    <tr>
-                                        <td>1</td>
-                                        <td>Dakota Rice</td>
-                                        <td>$36,738</td>
-                                        <td>Niger</td>
-                                        <td>Oud-Turnhout</td>
-                                    </tr>
-                                    <tr>
-                                        <td>2</td>
-                                        <td>Minerva Hooper</td>
-                                        <td>$23,789</td>
-                                        <td>Curaçao</td>
-                                        <td>Sinaai-Waas</td>
-                                    </tr>
-                                    <tr>
-                                        <td>3</td>
-                                        <td>Sage Rodriguez</td>
-                                        <td>$56,142</td>
-                                        <td>Netherlands</td>
-                                        <td>Baileux</td>
-                                    </tr>
-                                    <tr>
-                                        <td>4</td>
-                                        <td>Philip Chaney</td>
-                                        <td>$38,735</td>
-                                        <td>Korea, South</td>
-                                        <td>Overland Park</td>
-                                    </tr>
-                                    <tr>
-                                        <td>5</td>
-                                        <td>Doris Greene</td>
-                                        <td>$63,542</td>
-                                        <td>Malawi</td>
-                                        <td>Feldkirchen in Kärnten</td>
-                                    </tr>
-                                    <tr>
-                                        <td>6</td>
-                                        <td>Mason Porter</td>
-                                        <td>$78,615</td>
-                                        <td>Chile</td>
-                                        <td>Gloucester</td>
-                                    </tr>
+                                    <th:block th:each="object, i : ${data}">
+
+                                        <tr>
+                                            <th:block th:each="field, i : ${entity.getColumns}">
+                                                <th:block th:if="${i.count le 6}">
+                                                    <th:block th:if="${field.getRelationType().name() != 'NON_RELATIONSHIP'}">
+                                                        <td>
+                                                            <span th:text="${field.getRelationType()}"></span>
+                                                        </td>
+                                                    </th:block>
+
+                                                    <th:block th:if="${field.getRelationType().name() == 'NON_RELATIONSHIP'}">
+                                                        <td>
+                                                            <span style="display:block; text-overflow: ellipsis; overflow:hidden; width:100px; white-space: nowrap; word-break: break-all"
+                                                                    th:text="${@adminBoardFactory.getFieldMappingValue(object, field.getName())}"></span>
+                                                        </td>
+                                                    </th:block>
+
+<!--                                            <td>1</td>-->
+<!--                                            <td>Dakota Rice</td>-->
+<!--                                            <td>$36,738</td>-->
+<!--                                            <td>Niger</td>-->
+<!--                                            <td>Oud-Turnhout</td>-->
+                                                </th:block>
+                                            </th:block>
+                                        </tr>
+                                    </th:block>
+<!--                                    <tr>-->
+<!--                                        <td>2</td>-->
+<!--                                        <td>Minerva Hooper</td>-->
+<!--                                        <td>$23,789</td>-->
+<!--                                        <td>Curaçao</td>-->
+<!--                                        <td>Sinaai-Waas</td>-->
+<!--                                    </tr>-->
+<!--                                    <tr>-->
+<!--                                        <td>3</td>-->
+<!--                                        <td>Sage Rodriguez</td>-->
+<!--                                        <td>$56,142</td>-->
+<!--                                        <td>Netherlands</td>-->
+<!--                                        <td>Baileux</td>-->
+<!--                                    </tr>-->
+<!--                                    <tr>-->
+<!--                                        <td>4</td>-->
+<!--                                        <td>Philip Chaney</td>-->
+<!--                                        <td>$38,735</td>-->
+<!--                                        <td>Korea, South</td>-->
+<!--                                        <td>Overland Park</td>-->
+<!--                                    </tr>-->
+<!--                                    <tr>-->
+<!--                                        <td>5</td>-->
+<!--                                        <td>Doris Greene</td>-->
+<!--                                        <td>$63,542</td>-->
+<!--                                        <td>Malawi</td>-->
+<!--                                        <td>Feldkirchen in Kärnten</td>-->
+<!--                                    </tr>-->
+<!--                                    <tr>-->
+<!--                                        <td>6</td>-->
+<!--                                        <td>Mason Porter</td>-->
+<!--                                        <td>$78,615</td>-->
+<!--                                        <td>Chile</td>-->
+<!--                                        <td>Gloucester</td>-->
+<!--                                    </tr>-->
                                     </tbody>
                                 </table>
                             </div>

--- a/src/main/resources/templates/entity.html
+++ b/src/main/resources/templates/entity.html
@@ -1,0 +1,307 @@
+<!--
+=========================================================
+ Light Bootstrap Dashboard - v2.0.1
+=========================================================
+
+ Product Page: https://www.creative-tim.com/product/light-bootstrap-dashboard
+ Copyright 2019 Creative Tim (https://www.creative-tim.com)
+ Licensed under MIT (https://github.com/creativetimofficial/light-bootstrap-dashboard/blob/master/LICENSE)
+
+ Coded by Creative Tim
+
+=========================================================
+
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.  -->
+<!DOCTYPE html>
+<html lang="en">
+
+<th:block th:replace="~{fragments/header :: AdminHeadFragment}"/>
+
+<body>
+<div class="wrapper">
+    <th:block th:replace="~{fragments/sidebar :: SideBarFragment}"/>
+    <div class="main-panel">
+        <!-- Navbar -->
+        <nav class="navbar navbar-expand-lg " color-on-scroll="500">
+            <div class="container-fluid">
+                <a class="navbar-brand" href="#pablo"> Admin Users</a>
+                <button href="" class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" aria-controls="navigation-index" aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-bar burger-lines"></span>
+                    <span class="navbar-toggler-bar burger-lines"></span>
+                    <span class="navbar-toggler-bar burger-lines"></span>
+                </button>
+                <div class="collapse navbar-collapse justify-content-end" id="navigation">
+                    <ul class="nav navbar-nav mr-auto">
+                        <li class="nav-item">
+                            <a href="#" class="nav-link" data-toggle="dropdown">
+                                <i class="nc-icon nc-palette"></i>
+                                <span class="d-lg-none">Dashboard</span>
+                            </a>
+                        </li>
+                        <li class="dropdown nav-item">
+                            <a href="#" class="dropdown-toggle nav-link" data-toggle="dropdown">
+                                <i class="nc-icon nc-planet"></i>
+                                <span class="notification">5</span>
+                                <span class="d-lg-none">Notification</span>
+                            </a>
+                            <ul class="dropdown-menu">
+                                <a class="dropdown-item" href="#">Notification 1</a>
+                                <a class="dropdown-item" href="#">Notification 2</a>
+                                <a class="dropdown-item" href="#">Notification 3</a>
+                                <a class="dropdown-item" href="#">Notification 4</a>
+                                <a class="dropdown-item" href="#">Another notification</a>
+                            </ul>
+                        </li>
+                        <li class="nav-item">
+                            <a href="#" class="nav-link">
+                                <i class="nc-icon nc-zoom-split"></i>
+                                <span class="d-lg-block">&nbsp;Search</span>
+                            </a>
+                        </li>
+                    </ul>
+                    <ul class="navbar-nav ml-auto">
+                        <li class="nav-item">
+                            <a class="nav-link" href="#pablo">
+                                <span class="no-icon">Account</span>
+                            </a>
+                        </li>
+                        <li class="nav-item dropdown">
+                            <a class="nav-link dropdown-toggle" href="http://example.com" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="no-icon">Dropdown</span>
+                            </a>
+                            <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                                <a class="dropdown-item" href="#">Action</a>
+                                <a class="dropdown-item" href="#">Another action</a>
+                                <a class="dropdown-item" href="#">Something</a>
+                                <a class="dropdown-item" href="#">Something else here</a>
+                                <div class="divider"></div>
+                                <a class="dropdown-item" href="#">Separated link</a>
+                            </div>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="#pablo">
+                                <span class="no-icon">Log out</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+        <!-- End Navbar -->
+        <div class="content">
+            <div class="container-fluid">
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="card strpied-tabled-with-hover">
+                            <div class="card-header ">
+                                <h4 class="card-title">Admin User Table</h4>
+                                <p class="card-category">AdminBoard를 이용할 수 있는 Admin 계정 데이터 테이블입니다.</p>
+                            </div>
+                            <div class="card-body table-full-width table-responsive">
+                                <table class="table table-hover table-striped">
+                                    <thead>
+                                    <th>ID</th>
+                                    <th>Name</th>
+                                    <th>Salary</th>
+                                    <th>Country</th>
+                                    <th>City</th>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td>1</td>
+                                        <td>Dakota Rice</td>
+                                        <td>$36,738</td>
+                                        <td>Niger</td>
+                                        <td>Oud-Turnhout</td>
+                                    </tr>
+                                    <tr>
+                                        <td>2</td>
+                                        <td>Minerva Hooper</td>
+                                        <td>$23,789</td>
+                                        <td>Curaçao</td>
+                                        <td>Sinaai-Waas</td>
+                                    </tr>
+                                    <tr>
+                                        <td>3</td>
+                                        <td>Sage Rodriguez</td>
+                                        <td>$56,142</td>
+                                        <td>Netherlands</td>
+                                        <td>Baileux</td>
+                                    </tr>
+                                    <tr>
+                                        <td>4</td>
+                                        <td>Philip Chaney</td>
+                                        <td>$38,735</td>
+                                        <td>Korea, South</td>
+                                        <td>Overland Park</td>
+                                    </tr>
+                                    <tr>
+                                        <td>5</td>
+                                        <td>Doris Greene</td>
+                                        <td>$63,542</td>
+                                        <td>Malawi</td>
+                                        <td>Feldkirchen in Kärnten</td>
+                                    </tr>
+                                    <tr>
+                                        <td>6</td>
+                                        <td>Mason Porter</td>
+                                        <td>$78,615</td>
+                                        <td>Chile</td>
+                                        <td>Gloucester</td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <nav aria-label="Page navigation example">
+                                <ul class="pagination justify-content-center">
+                                    <li class="page-item disabled">
+                                        <a class="page-link">Previous</a>
+                                    </li>
+                                    <li class="page-item"><a class="page-link" href="#">1</a></li>
+                                    <li class="page-item"><a class="page-link" href="#">2</a></li>
+                                    <li class="page-item"><a class="page-link" href="#">3</a></li>
+                                    <li class="page-item">
+                                        <a class="page-link" href="#">Next</a>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <footer class="footer">
+            <div class="container-fluid">
+                <nav>
+                    <ul class="footer-menu">
+                        <li>
+                            <a href="#">
+                                Home
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#">
+                                Company
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#">
+                                Portfolio
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#">
+                                Blog
+                            </a>
+                        </li>
+                    </ul>
+                    <p class="copyright text-center">
+                        ©
+                        <script>
+                            document.write(new Date().getFullYear())
+                        </script>
+                        <a href="http://www.creative-tim.com">Creative Tim</a>, made with love for a better web
+                    </p>
+                </nav>
+            </div>
+        </footer>
+    </div>
+</div>
+<!--   -->
+<!-- <div class="fixed-plugin">
+<div class="dropdown show-dropdown">
+    <a href="#" data-toggle="dropdown">
+        <i class="fa fa-cog fa-2x"> </i>
+    </a>
+
+    <ul class="dropdown-menu">
+        <li class="header-title"> Sidebar Style</li>
+        <li class="adjustments-line">
+            <a href="javascript:void(0)" class="switch-trigger">
+                <p>Background Image</p>
+                <label class="switch">
+                    <input type="checkbox" data-toggle="switch" checked="" data-on-color="primary" data-off-color="primary"><span class="toggle"></span>
+                </label>
+                <div class="clearfix"></div>
+            </a>
+        </li>
+        <li class="adjustments-line">
+            <a href="javascript:void(0)" class="switch-trigger background-color">
+                <p>Filters</p>
+                <div class="pull-right">
+                    <span class="badge filter badge-black" data-color="black"></span>
+                    <span class="badge filter badge-azure" data-color="azure"></span>
+                    <span class="badge filter badge-green" data-color="green"></span>
+                    <span class="badge filter badge-orange" data-color="orange"></span>
+                    <span class="badge filter badge-red" data-color="red"></span>
+                    <span class="badge filter badge-purple active" data-color="purple"></span>
+                </div>
+                <div class="clearfix"></div>
+            </a>
+        </li>
+        <li class="header-title">Sidebar Images</li>
+
+        <li class="active">
+            <a class="img-holder switch-trigger" href="javascript:void(0)">
+                <img src="../assets/img/sidebar-1.jpg" alt="" />
+            </a>
+        </li>
+        <li>
+            <a class="img-holder switch-trigger" href="javascript:void(0)">
+                <img src="../assets/img/sidebar-3.jpg" alt="" />
+            </a>
+        </li>
+        <li>
+            <a class="img-holder switch-trigger" href="javascript:void(0)">
+                <img src="..//assets/img/sidebar-4.jpg" alt="" />
+            </a>
+        </li>
+        <li>
+            <a class="img-holder switch-trigger" href="javascript:void(0)">
+                <img src="../assets/img/sidebar-5.jpg" alt="" />
+            </a>
+        </li>
+
+        <li class="button-container">
+            <div class="">
+                <a href="http://www.creative-tim.com/product/light-bootstrap-dashboard" target="_blank" class="btn btn-info btn-block btn-fill">Download, it's free!</a>
+            </div>
+        </li>
+
+        <li class="header-title pro-title text-center">Want more components?</li>
+
+        <li class="button-container">
+            <div class="">
+                <a href="http://www.creative-tim.com/product/light-bootstrap-dashboard-pro" target="_blank" class="btn btn-warning btn-block btn-fill">Get The PRO Version!</a>
+            </div>
+        </li>
+
+        <li class="header-title" id="sharrreTitle">Thank you for sharing!</li>
+
+        <li class="button-container">
+            <button id="twitter" class="btn btn-social btn-outline btn-twitter btn-round sharrre"><i class="fa fa-twitter"></i> · 256</button>
+            <button id="facebook" class="btn btn-social btn-outline btn-facebook btn-round sharrre"><i class="fa fa-facebook-square"></i> · 426</button>
+        </li>
+    </ul>
+</div>
+</div>
+-->
+</body>
+<!--   Core JS Files   -->
+<script src="/adminboard-resources/assets/js/core/jquery.3.2.1.min.js" type="text/javascript"></script>
+<script src="/adminboard-resources/assets/js/core/popper.min.js" type="text/javascript"></script>
+<script src="/adminboard-resources/assets/js/core/bootstrap.min.js" type="text/javascript"></script>
+<!--  Plugin for Switches, full documentation here: http://www.jque.re/plugins/version3/bootstrap.switch/ -->
+<script src="/adminboard-resources/assets/js/plugins/bootstrap-switch.js"></script>
+<!--  Google Maps Plugin    -->
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=YOUR_KEY_HERE"></script>
+<!--  Chartist Plugin  -->
+<script src="/adminboard-resources/assets/js/plugins/chartist.min.js"></script>
+<!--  Notifications Plugin    -->
+<script src="/adminboard-resources/assets/js/plugins/bootstrap-notify.js"></script>
+<!-- Control Center for Light Bootstrap Dashboard: scripts for the example pages etc -->
+<script src="/adminboard-resources/assets/js/light-bootstrap-dashboard.js?v=2.0.0 " type="text/javascript"></script>
+<!-- Light Bootstrap Dashboard DEMO methods, don't include it in your project! -->
+<script src="/adminboard-resources/assets/js/demo.js"></script>
+
+</html>

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -25,45 +25,55 @@
                     </a>
                 </li>
 
-                <div class="logo" style="padding-left:30px">
-                    Group
-                </div>
-                <li>
-                    <a class="nav-link" th:href="@{/admin-board/user}">
-                        <i class="nc-icon nc-circle-09"></i>
-                        <p>User</p>
-                    </a>
-                </li>
-                <li>
-                    <a class="nav-link" th:href="@{/admin-board/table}">
-                        <i class="nc-icon nc-notes"></i>
-                        <p>Table List</p>
-                    </a>
-                </li>
-                <li>
-                    <a class="nav-link" th:href="@{/admin-board/typography}">
-                        <i class="nc-icon nc-paper-2"></i>
-                        <p>Typography</p>
-                    </a>
-                </li>
-                <li>
-                    <a class="nav-link" th:href="@{/admin-board/icons}">
-                        <i class="nc-icon nc-atom"></i>
-                        <p>Icons</p>
-                    </a>
-                </li>
-                <li>
-                    <a class="nav-link" th:href="@{/admin-board/maps}">
-                        <i class="nc-icon nc-pin-3"></i>
-                        <p>Maps</p>
-                    </a>
-                </li>
-                <li>
-                    <a class="nav-link" th:href="@{/admin-board/notifications}">
-                        <i class="nc-icon nc-bell-55"></i>
-                        <p>Notifications</p>
-                    </a>
-                </li>
+                <th:block th:each="group, index : ${entitiesByGroup}">
+                    <div class="logo" style="padding-left:30px">
+                        <span th:text="${group.key}"></span>
+                    </div>
+                    <th:block th:each="entity, index : ${group.value}">
+                        <li>
+                            <a class="nav-link" th:href="@{/admin-board/{entityName}(entityName=${entity.getName()})}">
+                                <i class="nc-icon nc-circle-09"></i>
+                                <p th:text="${entity.getDisplayName()}"></p>
+                            </a>
+                        </li>
+                    </th:block>
+                    </th:block>
+<!--                <li>-->
+<!--                    <a class="nav-link" th:href="@{/admin-board/user}">-->
+<!--                        <i class="nc-icon nc-circle-09"></i>-->
+<!--                        <p>User</p>-->
+<!--                    </a>-->
+<!--                </li>-->
+<!--                <li>-->
+<!--                    <a class="nav-link" th:href="@{/admin-board/table}">-->
+<!--                        <i class="nc-icon nc-notes"></i>-->
+<!--                        <p>Table List</p>-->
+<!--                    </a>-->
+<!--                </li>-->
+<!--                <li>-->
+<!--                    <a class="nav-link" th:href="@{/admin-board/typography}">-->
+<!--                        <i class="nc-icon nc-paper-2"></i>-->
+<!--                        <p>Typography</p>-->
+<!--                    </a>-->
+<!--                </li>-->
+<!--                <li>-->
+<!--                    <a class="nav-link" th:href="@{/admin-board/icons}">-->
+<!--                        <i class="nc-icon nc-atom"></i>-->
+<!--                        <p>Icons</p>-->
+<!--                    </a>-->
+<!--                </li>-->
+<!--                <li>-->
+<!--                    <a class="nav-link" th:href="@{/admin-board/maps}">-->
+<!--                        <i class="nc-icon nc-pin-3"></i>-->
+<!--                        <p>Maps</p>-->
+<!--                    </a>-->
+<!--                </li>-->
+<!--                <li>-->
+<!--                    <a class="nav-link" th:href="@{/admin-board/notifications}">-->
+<!--                        <i class="nc-icon nc-bell-55"></i>-->
+<!--                        <p>Notifications</p>-->
+<!--                    </a>-->
+<!--                </li>-->
 <!--                <li class="nav-item nav-link active-pro">-->
 <!--                    <a class="nav-link active" th:href="@{/admin-board/upgrade}">-->
 <!--                        <i class="nc-icon nc-alien-33"></i>-->

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -7,9 +7,9 @@
 -->
         <div class="sidebar-wrapper">
             <div class="logo">
-                <a href="https://github.com/orgs/twentiethcenturygangsta/repositories" class="simple-text">
-                    ADMIN BOARD
+                <a href="https://github.com/orgs/twentiethcenturygangsta/repositories" class="simple-text" th:text="${adminBoardInformation.get('title')}">
                 </a>
+                <div style="text-align: center; font-size: 10px; font-weight: 400" th:text="${adminBoardInformation.get('description')}"></div>
             </div>
             <ul class="nav">
                 <li>

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -13,8 +13,8 @@
             </div>
             <ul class="nav">
                 <li>
-                    <a class="nav-link" th:href="@{/admin-board/home}">
-                        <i class="nc-icon nc-chart-pie-35"></i>
+                    <a class="nav-link" th:href="@{/admin-board/admin-user}">
+                        <i class="nc-icon nc-circle-09"></i>
                         <p>ADMIN USERS</p>
                     </a>
                 </li>
@@ -24,6 +24,7 @@
                         <p>TASKS</p>
                     </a>
                 </li>
+
                 <div class="logo" style="padding-left:30px">
                     Group
                 </div>

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -37,13 +37,13 @@
                             </a>
                         </li>
                     </th:block>
-                    </th:block>
-<!--                <li>-->
-<!--                    <a class="nav-link" th:href="@{/admin-board/user}">-->
-<!--                        <i class="nc-icon nc-circle-09"></i>-->
-<!--                        <p>User</p>-->
-<!--                    </a>-->
-<!--                </li>-->
+                </th:block>
+                <li>
+                    <a class="nav-link" th:href="@{/admin-board/user}">
+                        <i class="nc-icon nc-circle-09"></i>
+                        <p>User</p>
+                    </a>
+                </li>
 <!--                <li>-->
 <!--                    <a class="nav-link" th:href="@{/admin-board/table}">-->
 <!--                        <i class="nc-icon nc-notes"></i>-->

--- a/src/main/resources/templates/fragments/sidebarTemp.html
+++ b/src/main/resources/templates/fragments/sidebarTemp.html
@@ -20,19 +20,13 @@
                 </li>
                 <li>
                     <a class="nav-link" th:href="@{/admin-board/tasks}">
-                        <i class="nc-icon nc-notes"></i>
+                        <i class="nc-icon nc-circle-09"></i>
                         <p>TASKS</p>
                     </a>
                 </li>
                 <div class="logo" style="padding-left:30px">
                     Group
                 </div>
-                <li>
-                    <a class="nav-link" th:href="@{/admin-board/user}">
-                        <i class="nc-icon nc-circle-09"></i>
-                        <p>User</p>
-                    </a>
-                </li>
                 <li>
                     <a class="nav-link" th:href="@{/admin-board/table}">
                         <i class="nc-icon nc-notes"></i>

--- a/src/main/resources/templates/objectDetail.html
+++ b/src/main/resources/templates/objectDetail.html
@@ -20,11 +20,12 @@
 <body>
 <div class="wrapper">
     <th:block th:replace="~{fragments/sidebar :: SideBarFragment}"/>
+
     <div class="main-panel">
         <!-- Navbar -->
         <nav class="navbar navbar-expand-lg " color-on-scroll="500">
             <div class="container-fluid">
-                <a class="navbar-brand" href="#pablo" th:text="${groupName}"></a>
+                <a class="navbar-brand" href="#pablo"th:text="${entityName}"></a>
                 <button href="" class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" aria-controls="navigation-index" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-bar burger-lines"></span>
                     <span class="navbar-toggler-bar burger-lines"></span>
@@ -92,118 +93,145 @@
             <div class="container-fluid">
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="card strpied-tabled-with-hover">
-                            <div class="card-header ">
-                                <h4 class="card-title"><span th:text="${entityName}"></span> Table </h4>
-                                <p class="card-category"><span th:text="${entity.getDescription()}"></span></p>
+                        <div class="card">
+                            <div class="card-header">
+                                <h4 class="card-title" th:text="${entityName}"></h4>
                             </div>
-                            <div class="card-body table-full-width table-responsive">
-                                <table class="table table-hover table-striped">
-                                    <thead>
-                                    <th:block th:each="field, i : ${entity.getColumns()}">
-                                        <th:block th:if="${i.count le 6}">
-                                            <th>
-                                                <span th:text="${field.getName()}"></span>
-                                            </th>
-                                        </th:block>
-<!--                                    <th>ID</th>-->
-<!--                                    <th>Name</th>-->
-<!--                                    <th>Salary</th>-->
-<!--                                    <th>Country</th>-->
-<!--                                    <th>City</th>-->
-                                    </th:block>
-                                    </thead>
-                                    <tbody>
-                                    <th:block th:each="object, i : ${data}">
+                            <div class="card-body">
+<!--                                <th:block th:each="field, i : ${entity.getColumns}">-->
+<!--                                    <span th:text="${field.getName()}"></span>-->
+<!--                                    <span th:text="${field.getDescription()}"></span>-->
+<!--                                    <span th:text=""></span>-->
+<!--                                </th:block>-->
+                                <form>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <div class="form-group">
+                                                <th:block th:each="field, i : ${entity.getColumns}">
+                                                    <label>
+                                                        <span th:text="${field.getName()}" style="margin-right:10px"></span>
+                                                        <span th:text="${field.getDescription()}" style="color: rebeccapurple; font-size: 10px"></span>
+                                                    </label>
+                                                    <th:block th:if="${field.getRelationType().name() == 'ONE_TO_MANY'}">
 
-                                        <tr style="cursor:hand">
-                                            <th:block th:each="field, i : ${entity.getColumns}">
-                                                <th:block th:if="${i.count le 6}">
-                                                    <th:block th:if="${field.getRelationType().name() != 'NON_RELATIONSHIP'}">
-                                                        <td>
-                                                            <span th:text="${field.getRelationType()}"></span>
-                                                        </td>
+                                                         <div class="col-md-12" style = "height: 500px; overflow: scroll">
+
+                                                                <th:block th:each="value, i :${@adminBoardFactory.getFieldMappingValue(object, field.getName())}">
+                                                                    <div class="card-body">
+
+                                                                        <th:block th:each="field1, j:${@adminBoardFactory.getEntity(value.getClass().getSimpleName()).getColumns()}">
+                                                                            <label>
+                                                                                <span th:text="${field1.getName()}" style="margin-right:10px"></span>
+                                                                                <span th:text="${field1.getDescription()}" style="color: rebeccapurple; font-size: 10px"></span>
+                                                                            </label>
+                                                                            <input type="text" class="form-control" disabled="" placeholder="Company" th:value="${@adminBoardFactory.getFieldMappingValue(value, field1.getName())}" style="margin-bottom: 10px">
+                                                                        </th:block>
+                                                                    </div>
+                                                                    <br />
+                                                                    <!--                                                                <th:block th:each="field, i : ${entities.get(value).getColumns}">-->
+    <!--                                                                </th:block>-->
+                                                                </th:block>
+                                                        </div>
                                                     </th:block>
 
-                                                    <th:block th:if="${field.getRelationType().name() == 'NON_RELATIONSHIP'}">
-                                                        <th:block th:if="${field.getIsId() == true}">
-                                                            <td>
-                                                                <a style="display:block; text-overflow: ellipsis; overflow:hidden; width:100px; white-space: nowrap; word-break: break-all;"
-                                                                      th:text="${@adminBoardFactory.getFieldMappingValue(object, field.getName())}"
-                                                                      th:href="@{/admin-board/{entityName}/{id} (entityName=${entityName}, id=${@adminBoardFactory.getFieldMappingValue(object, field.getName())})}"
-                                                                ></a>
-                                                            </td>
-                                                        </th:block>
-                                                        <th:block th:if="${field.getIsId() == false}">
-                                                            <td>
-                                                                <span style="display:block; text-overflow: ellipsis; overflow:hidden; width:100px; white-space: nowrap; word-break: break-all"
-                                                                        th:text="${@adminBoardFactory.getFieldMappingValue(object, field.getName())}"></span>
-                                                            </td>
-                                                        </th:block>
+                                                    <th:block th:if="${field.getRelationType().name() != 'ONE_TO_MANY'}">
+                                                        <input type="text" class="form-control" disabled="" placeholder="Company" th:value="${@adminBoardFactory.getFieldMappingValue(object, field.getName())}" style="margin-bottom: 10px">
                                                     </th:block>
-
-<!--                                            <td>1</td>-->
-<!--                                            <td>Dakota Rice</td>-->
-<!--                                            <td>$36,738</td>-->
-<!--                                            <td>Niger</td>-->
-<!--                                            <td>Oud-Turnhout</td>-->
                                                 </th:block>
-                                            </th:block>
-                                        </tr>
-                                    </th:block>
-<!--                                    <tr>-->
-<!--                                        <td>2</td>-->
-<!--                                        <td>Minerva Hooper</td>-->
-<!--                                        <td>$23,789</td>-->
-<!--                                        <td>Curaçao</td>-->
-<!--                                        <td>Sinaai-Waas</td>-->
-<!--                                    </tr>-->
-<!--                                    <tr>-->
-<!--                                        <td>3</td>-->
-<!--                                        <td>Sage Rodriguez</td>-->
-<!--                                        <td>$56,142</td>-->
-<!--                                        <td>Netherlands</td>-->
-<!--                                        <td>Baileux</td>-->
-<!--                                    </tr>-->
-<!--                                    <tr>-->
-<!--                                        <td>4</td>-->
-<!--                                        <td>Philip Chaney</td>-->
-<!--                                        <td>$38,735</td>-->
-<!--                                        <td>Korea, South</td>-->
-<!--                                        <td>Overland Park</td>-->
-<!--                                    </tr>-->
-<!--                                    <tr>-->
-<!--                                        <td>5</td>-->
-<!--                                        <td>Doris Greene</td>-->
-<!--                                        <td>$63,542</td>-->
-<!--                                        <td>Malawi</td>-->
-<!--                                        <td>Feldkirchen in Kärnten</td>-->
-<!--                                    </tr>-->
-<!--                                    <tr>-->
-<!--                                        <td>6</td>-->
-<!--                                        <td>Mason Porter</td>-->
-<!--                                        <td>$78,615</td>-->
-<!--                                        <td>Chile</td>-->
-<!--                                        <td>Gloucester</td>-->
-<!--                                    </tr>-->
-                                    </tbody>
-                                </table>
+                                            </div>
+                                        </div>
+                                    </div>
+<!--                                    <div class="row">-->
+<!--                                        <div class="col-md-6 pr-1">-->
+<!--                                            <div class="form-group">-->
+<!--                                                <label>First Name</label>-->
+<!--                                                <input type="text" class="form-control" placeholder="Company" value="Mike">-->
+<!--                                            </div>-->
+<!--                                        </div>-->
+<!--                                        <div class="col-md-6 pl-1">-->
+<!--                                            <div class="form-group">-->
+<!--                                                <label>Last Name</label>-->
+<!--                                                <input type="text" class="form-control" placeholder="Last Name" value="Andrew">-->
+<!--                                            </div>-->
+<!--                                        </div>-->
+<!--                                    </div>-->
+<!--                                    <div class="row">-->
+<!--                                        <div class="col-md-12">-->
+<!--                                            <div class="form-group">-->
+<!--                                                <label>Address</label>-->
+<!--                                                <input type="text" class="form-control" placeholder="Home Address" value="Bld Mihail Kogalniceanu, nr. 8 Bl 1, Sc 1, Ap 09">-->
+<!--                                            </div>-->
+<!--                                        </div>-->
+<!--                                    </div>-->
+<!--                                    <div class="row">-->
+<!--                                        <div class="col-md-4 pr-1">-->
+<!--                                            <div class="form-group">-->
+<!--                                                <label>City</label>-->
+<!--                                                <input type="text" class="form-control" placeholder="City" value="Mike">-->
+<!--                                            </div>-->
+<!--                                        </div>-->
+<!--                                        <div class="col-md-4 px-1">-->
+<!--                                            <div class="form-group">-->
+<!--                                                <label>Country</label>-->
+<!--                                                <input type="text" class="form-control" placeholder="Country" value="Andrew">-->
+<!--                                            </div>-->
+<!--                                        </div>-->
+<!--                                        <div class="col-md-4 pl-1">-->
+<!--                                            <div class="form-group">-->
+<!--                                                <label>Postal Code</label>-->
+<!--                                                <input type="number" class="form-control" placeholder="ZIP Code">-->
+<!--                                            </div>-->
+<!--                                        </div>-->
+<!--                                    </div>-->
+<!--                                    <div class="row">-->
+<!--                                        <div class="col-md-12">-->
+<!--                                            <div class="form-group">-->
+<!--                                                <label>About Me</label>-->
+<!--                                                <textarea rows="4" cols="80" class="form-control" placeholder="Here can be your description" value="Mike">Lamborghini Mercy, Your chick she so thirsty, I'm in that two seat Lambo.</textarea>-->
+<!--                                            </div>-->
+<!--                                        </div>-->
+<!--                                    </div>-->
+                                    <button type="submit" class="btn btn-info btn-fill pull-right">Update</button>
+                                    <div class="clearfix"></div>
+                                </form>
                             </div>
-                            <nav aria-label="Page navigation example">
-                                <ul class="pagination justify-content-center">
-                                    <li class="page-item disabled">
-                                        <a class="page-link">Previous</a>
-                                    </li>
-                                    <li class="page-item"><a class="page-link" href="#">1</a></li>
-                                    <li class="page-item"><a class="page-link" href="#">2</a></li>
-                                    <li class="page-item"><a class="page-link" href="#">3</a></li>
-                                    <li class="page-item">
-                                        <a class="page-link" href="#">Next</a>
-                                    </li>
-                                </ul>
-                            </nav>
                         </div>
                     </div>
+<!--                    <div class="col-md-4">-->
+<!--                        <div class="card card-user">-->
+<!--                            <div class="card-image">-->
+<!--                                <img src="https://ununsplash.imgix.net/photo-1431578500526-4d9613015464?fit=crop&fm=jpg&h=300&q=75&w=400" alt="...">-->
+<!--                            </div>-->
+<!--                            <div class="card-body">-->
+<!--                                <div class="author">-->
+<!--                                    <a href="#">-->
+<!--                                        <img class="avatar border-gray" src="../assets/img/faces/face-3.jpg" alt="...">-->
+<!--                                        <h5 class="title">Mike Andrew</h5>-->
+<!--                                    </a>-->
+<!--                                    <p class="description">-->
+<!--                                        michael24-->
+<!--                                    </p>-->
+<!--                                </div>-->
+<!--                                <p class="description text-center">-->
+<!--                                    "Lamborghini Mercy-->
+<!--                                    <br> Your chick she so thirsty-->
+<!--                                    <br> I'm in that two seat Lambo"-->
+<!--                                </p>-->
+<!--                            </div>-->
+<!--                            <hr>-->
+<!--                            <div class="button-container mr-auto ml-auto">-->
+<!--                                <button href="#" class="btn btn-simple btn-link btn-icon">-->
+<!--                                    <i class="fa fa-facebook-square"></i>-->
+<!--                                </button>-->
+<!--                                <button href="#" class="btn btn-simple btn-link btn-icon">-->
+<!--                                    <i class="fa fa-twitter"></i>-->
+<!--                                </button>-->
+<!--                                <button href="#" class="btn btn-simple btn-link btn-icon">-->
+<!--                                    <i class="fa fa-google-plus-square"></i>-->
+<!--                                </button>-->
+<!--                            </div>-->
+<!--                        </div>-->
+<!--                    </div>-->
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/tasks.html
+++ b/src/main/resources/templates/tasks.html
@@ -1,0 +1,324 @@
+<!--
+=========================================================
+ Light Bootstrap Dashboard - v2.0.1
+=========================================================
+
+ Product Page: https://www.creative-tim.com/product/light-bootstrap-dashboard
+ Copyright 2019 Creative Tim (https://www.creative-tim.com)
+ Licensed under MIT (https://github.com/creativetimofficial/light-bootstrap-dashboard/blob/master/LICENSE)
+
+ Coded by Creative Tim
+
+=========================================================
+
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.  -->
+<!DOCTYPE html>
+
+<html lang="en">
+
+<th:block th:replace="~{fragments/header :: AdminHeadFragment}"/>
+
+<body>
+<div class="wrapper">
+    <th:block th:replace="~{fragments/sidebar :: SideBarFragment}"/>
+
+    <div class="main-panel">
+        <!-- Navbar -->
+        <nav class="navbar navbar-expand-lg " color-on-scroll="500">
+            <div class="container-fluid">
+                <a class="navbar-brand" href="#pablo"> Dashboard </a>
+                <button href="" class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" aria-controls="navigation-index" aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-bar burger-lines"></span>
+                    <span class="navbar-toggler-bar burger-lines"></span>
+                    <span class="navbar-toggler-bar burger-lines"></span>
+                </button>
+                <div class="collapse navbar-collapse justify-content-end" id="navigation">
+                    <ul class="nav navbar-nav mr-auto">
+                        <li class="nav-item">
+                            <a href="#" class="nav-link" data-toggle="dropdown">
+                                <i class="nc-icon nc-palette"></i>
+                                <span class="d-lg-none">Dashboard</span>
+                            </a>
+                        </li>
+                        <li class="dropdown nav-item">
+                            <a href="#" class="dropdown-toggle nav-link" data-toggle="dropdown">
+                                <i class="nc-icon nc-planet"></i>
+                                <span class="notification">5</span>
+                                <span class="d-lg-none">Notification</span>
+                            </a>
+                            <ul class="dropdown-menu">
+                                <a class="dropdown-item" href="#">Notification 1</a>
+                                <a class="dropdown-item" href="#">Notification 2</a>
+                                <a class="dropdown-item" href="#">Notification 3</a>
+                                <a class="dropdown-item" href="#">Notification 4</a>
+                                <a class="dropdown-item" href="#">Another notification</a>
+                            </ul>
+                        </li>
+                        <li class="nav-item">
+                            <a href="#" class="nav-link">
+                                <i class="nc-icon nc-zoom-split"></i>
+                                <span class="d-lg-block">&nbsp;Search</span>
+                            </a>
+                        </li>
+                    </ul>
+                    <ul class="navbar-nav ml-auto">
+                        <li class="nav-item">
+                            <a class="nav-link" href="#pablo">
+                                <span class="no-icon">Account</span>
+                            </a>
+                        </li>
+                        <li class="nav-item dropdown">
+                            <a class="nav-link dropdown-toggle" href="http://example.com" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="no-icon">Dropdown</span>
+                            </a>
+                            <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                                <a class="dropdown-item" href="#">Action</a>
+                                <a class="dropdown-item" href="#">Another action</a>
+                                <a class="dropdown-item" href="#">Something</a>
+                                <a class="dropdown-item" href="#">Something else here</a>
+                                <div class="divider"></div>
+                                <a class="dropdown-item" href="#">Separated link</a>
+                            </div>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="#pablo">
+                                <span class="no-icon">Log out</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+        <!-- End Navbar -->
+        <div class="content">
+            <div class="container-fluid">
+                <div class="row">
+                    <div class="col-md-6">
+                        <div class="card  card-tasks">
+                            <div class="card-header ">
+                                <h4 class="card-title">Tasks</h4>
+                                <p class="card-category">Backend development</p>
+                            </div>
+                            <div class="card-body ">
+                                <div class="table-full-width">
+                                    <table class="table">
+                                        <tbody>
+                                        <tr>
+                                            <td>
+                                                <div class="form-check">
+                                                    <label class="form-check-label">
+                                                        <input class="form-check-input" type="checkbox" value="">
+                                                        <span class="form-check-sign"></span>
+                                                    </label>
+                                                </div>
+                                            </td>
+                                            <td>Sign contract for "What are conference organizers afraid of?"</td>
+                                            <td class="td-actions text-right">
+                                                <button type="button" rel="tooltip" title="Edit Task" class="btn btn-info btn-simple btn-link">
+                                                    <i class="fa fa-edit"></i>
+                                                </button>
+                                                <button type="button" rel="tooltip" title="Remove" class="btn btn-danger btn-simple btn-link">
+                                                    <i class="fa fa-times"></i>
+                                                </button>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>
+                                                <div class="form-check">
+                                                    <label class="form-check-label">
+                                                        <input class="form-check-input" type="checkbox" value="" checked>
+                                                        <span class="form-check-sign"></span>
+                                                    </label>
+                                                </div>
+                                            </td>
+                                            <td>Lines From Great Russian Literature? Or E-mails From My Boss?</td>
+                                            <td class="td-actions text-right">
+                                                <button type="button" rel="tooltip" title="Edit Task" class="btn btn-info btn-simple btn-link">
+                                                    <i class="fa fa-edit"></i>
+                                                </button>
+                                                <button type="button" rel="tooltip" title="Remove" class="btn btn-danger btn-simple btn-link">
+                                                    <i class="fa fa-times"></i>
+                                                </button>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>
+                                                <div class="form-check">
+                                                    <label class="form-check-label">
+                                                        <input class="form-check-input" type="checkbox" value="" checked>
+                                                        <span class="form-check-sign"></span>
+                                                    </label>
+                                                </div>
+                                            </td>
+                                            <td>Flooded: One year later, assessing what was lost and what was found when a ravaging rain swept through metro Detroit
+                                            </td>
+                                            <td class="td-actions text-right">
+                                                <button type="button" rel="tooltip" title="Edit Task" class="btn btn-info btn-simple btn-link">
+                                                    <i class="fa fa-edit"></i>
+                                                </button>
+                                                <button type="button" rel="tooltip" title="Remove" class="btn btn-danger btn-simple btn-link">
+                                                    <i class="fa fa-times"></i>
+                                                </button>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>
+                                                <div class="form-check">
+                                                    <label class="form-check-label">
+                                                        <input class="form-check-input" type="checkbox" checked>
+                                                        <span class="form-check-sign"></span>
+                                                    </label>
+                                                </div>
+                                            </td>
+                                            <td>Create 4 Invisible User Experiences you Never Knew About</td>
+                                            <td class="td-actions text-right">
+                                                <button type="button" rel="tooltip" title="Edit Task" class="btn btn-info btn-simple btn-link">
+                                                    <i class="fa fa-edit"></i>
+                                                </button>
+                                                <button type="button" rel="tooltip" title="Remove" class="btn btn-danger btn-simple btn-link">
+                                                    <i class="fa fa-times"></i>
+                                                </button>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>
+                                                <div class="form-check">
+                                                    <label class="form-check-label">
+                                                        <input class="form-check-input" type="checkbox" value="">
+                                                        <span class="form-check-sign"></span>
+                                                    </label>
+                                                </div>
+                                            </td>
+                                            <td>Read "Following makes Medium better"</td>
+                                            <td class="td-actions text-right">
+                                                <button type="button" rel="tooltip" title="Edit Task" class="btn btn-info btn-simple btn-link">
+                                                    <i class="fa fa-edit"></i>
+                                                </button>
+                                                <button type="button" rel="tooltip" title="Remove" class="btn btn-danger btn-simple btn-link">
+                                                    <i class="fa fa-times"></i>
+                                                </button>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>
+                                                <div class="form-check">
+                                                    <label class="form-check-label">
+                                                        <input class="form-check-input" type="checkbox" value="" disabled>
+                                                        <span class="form-check-sign"></span>
+                                                    </label>
+                                                </div>
+                                            </td>
+                                            <td>Unfollow 5 enemies from twitter</td>
+                                            <td class="td-actions text-right">
+                                                <button type="button" rel="tooltip" title="Edit Task" class="btn btn-info btn-simple btn-link">
+                                                    <i class="fa fa-edit"></i>
+                                                </button>
+                                                <button type="button" rel="tooltip" title="Remove" class="btn btn-danger btn-simple btn-link">
+                                                    <i class="fa fa-times"></i>
+                                                </button>
+                                            </td>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                            <div class="card-footer ">
+                                <hr>
+                                <div class="stats">
+<!--                                    <i class="now-ui-icons loader_refresh spin"></i> Updated 3 minutes ago-->
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="card ">
+                            <div class="card-header ">
+                                <h4 class="card-title">Add Task</h4>
+                                <p class="card-category">등록한 Task를 입력해주세요</p>
+                            </div>
+                            <div class="card-body">
+                                <form>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <div class="form-group">
+                                                <label>* Note</label>
+                                                <textarea rows="20" cols="80" class="form-control" style="height:100px" placeholder="Here can be your description" value="Mike">Lamborghini Mercy, Your chick she so thirsty, I'm in that two seat Lambo.</textarea>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="submit" class="btn btn-info btn-fill pull-right">Add</button>
+                                    <div class="clearfix"></div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <footer class="footer">
+            <div class="container-fluid">
+                <nav>
+                    <ul class="footer-menu">
+                        <li>
+                            <a href="#">
+                                Home
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#">
+                                Company
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#">
+                                Portfolio
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#">
+                                Blog
+                            </a>
+                        </li>
+                    </ul>
+                    <p class="copyright text-center">
+                        ©
+                        <script>
+                            document.write(new Date().getFullYear())
+                        </script>
+                        <a href="http://www.creative-tim.com">Creative Tim</a>, made with love for a better web
+                    </p>
+                </nav>
+            </div>
+        </footer>
+    </div>
+</div>
+
+</body>
+<!--   Core JS Files   -->
+<script src="/adminboard-resources/assets/js/core/jquery.3.2.1.min.js" type="text/javascript"></script>
+<script src="/adminboard-resources/assets/js/core/popper.min.js" type="text/javascript"></script>
+<script src="/adminboard-resources/assets/js/core/bootstrap.min.js" type="text/javascript"></script>
+<!--  Plugin for Switches, full documentation here: http://www.jque.re/plugins/version3/bootstrap.switch/ -->
+<script src="/adminboard-resources/assets/js/plugins/bootstrap-switch.js"></script>
+<!--  Google Maps Plugin    -->
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=YOUR_KEY_HERE"></script>
+<!--  Chartist Plugin  -->
+<script src="/adminboard-resources/assets/js/plugins/chartist.min.js"></script>
+<!--  Notifications Plugin    -->
+<script src="/adminboard-resources/assets/js/plugins/bootstrap-notify.js"></script>
+<!-- Control Center for Light Bootstrap Dashboard: scripts for the example pages etc -->
+<script src="/adminboard-resources/assets/js/light-bootstrap-dashboard.js?v=2.0.0 " type="text/javascript"></script>
+<!-- Light Bootstrap Dashboard DEMO methods, don't include it in your project! -->
+<script src="/adminboard-resources/assets/js/demo.js"></script>
+<script type="text/javascript">
+    $(document).ready(function() {
+        // Javascript method's body can be found in assets/js/demos.js
+        demo.initDashboardPageCharts();
+
+        demo.showNotification();
+
+    });
+
+</script>
+
+</html>


### PR DESCRIPTION
## Description
- DashBoard 에서 Entity 목록, object 목록, object의 상세 정보를 전달하는 View와 로직 추가

## Implementation
- [x] : sidebar에 Entity list 출력 로직 추가
- [x] : Entity의 Object list 로직 추가
- [x] : Object Detail View 추가
- [x] : Object field data 중 ONE_TO_MANY인 경우 해당하는 Object list 추가
- [x] : column 이름과 설명을 view에 추가 (AdminBoardColumn annotation을 통해 받아오는 데이터)  

## ScreenShot
- 특정 Entity의 Object list view

<img width="1433" alt="스크린샷 2023-05-21 오전 9 38 25" src="https://github.com/twentiethcenturygangsta/admin-board/assets/49235528/8c8ce973-ccb0-4c84-add7-0b79627791b3">

- Object detail view
<img width="1421" alt="스크린샷 2023-05-21 오전 9 39 09" src="https://github.com/twentiethcenturygangsta/admin-board/assets/49235528/6bffbfab-a419-49f4-9f8a-0a032a9aad90">